### PR TITLE
Optimise the support for <script>, <style> and other similar non-html elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Golang HTML Sanitizer
+# Golang HTML Sanitizer / Filter
 
-![Go](https://github.com/SYM01/htmlsanitizer/workflows/Go/badge.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/sym01/htmlsanitizer.svg)](https://pkg.go.dev/github.com/sym01/htmlsanitizer)
+[![Go](https://github.com/SYM01/htmlsanitizer/workflows/Go/badge.svg)](https://github.com/SYM01/htmlsanitizer/actions/workflows/go.yml)
 [![codecov](https://codecov.io/gh/SYM01/htmlsanitizer/branch/master/graph/badge.svg)](https://codecov.io/gh/SYM01/htmlsanitizer)
 
 
-htmlsanitizer is a super fast, allowlist-based HTML sanitizer written in Golang. A built-in, secure-by-default allowlist helps you filter out any dangerous HTML content.
+htmlsanitizer is a super fast, allowlist-based HTML sanitizer (HTML filter) written in Golang. A built-in, secure-by-default allowlist helps you filter out any dangerous HTML content.
 
 Why use htmlsanitizer?
 

--- a/cmd/htmlsanitizer/main.go
+++ b/cmd/htmlsanitizer/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/sym01/htmlsanitizer"
+)
+
+var (
+	srcFilePath = flag.String("src", "", "could be either source file path, or the source URL")
+)
+
+func main() {
+	flag.Parse()
+
+	if len(*srcFilePath) == 0 {
+		flag.CommandLine.Usage()
+		return
+	}
+
+	var src io.ReadCloser
+	switch {
+	case strings.HasPrefix(*srcFilePath, "http://"), strings.HasPrefix(*srcFilePath, "https://"):
+		resp, err := http.Get(*srcFilePath)
+		if err != nil {
+			log.Fatalf("unable to fetch remote content: %s", err)
+		}
+		src = resp.Body
+	default:
+		file, err := os.OpenFile(*srcFilePath, os.O_RDONLY, 0755)
+		if err != nil {
+			log.Fatalf("unable to open src file: %s", err)
+		}
+		src = file
+	}
+
+	defer src.Close()
+
+	san := htmlsanitizer.NewHTMLSanitizer()
+	writer := san.NewWriter(os.Stdout)
+	if _, err := io.Copy(writer, src); err != nil {
+		log.Printf("unable to sanitize HTML content: %s", err)
+	}
+}

--- a/dfa.go
+++ b/dfa.go
@@ -218,7 +218,7 @@ func (w *writer) sNORMAL() (err error) {
 	}
 
 	_, err = w.flush()
-	return err
+	return
 }
 
 func (w *writer) sNONHTML() (err error) {
@@ -242,7 +242,7 @@ func (w *writer) sNONHTML() (err error) {
 	}
 
 	_, err = w.flush()
-	return err
+	return
 }
 
 func (w *writer) sLTSIGN() error {

--- a/dfa.go
+++ b/dfa.go
@@ -294,6 +294,7 @@ func (w *writer) sTAGNAME() error {
 			w.lastByte = b
 
 			w.tag = w.FindTag(w.tagName)
+			w.nonHTMLTag = w.checkNonHTMLTag(w.tagName)
 			if w.tag == nil {
 				return nil
 			}

--- a/dfa.go
+++ b/dfa.go
@@ -55,7 +55,6 @@ type writer struct {
 	tagName  []byte
 	tag      *Tag
 	attr     []byte
-	urlAttr  bool
 	val      []byte
 	quote    byte
 	lastByte byte // last byte for ATTRGAP
@@ -105,7 +104,6 @@ func (w *writer) safeAppend(p []byte) {
 			w.buf = append(w.buf, b)
 		}
 	}
-	return
 }
 
 // write tag attribute and its sanitzed value if legal.

--- a/sanitizer_fuzz_test.go
+++ b/sanitizer_fuzz_test.go
@@ -36,21 +36,3 @@ func FuzzSanitize(f *testing.F) {
 		}
 	})
 }
-
-func TestSanitize_tmp(t *testing.T) {
-	a := []byte(`</A>`)
-	data := append([]byte(`abc<script>`), a...)
-	data = append(data, `abc</script>def<style>`...)
-	data = append(data, a...)
-	data = append(data, `</style ...>(g)`...)
-	expected := []byte(`abcdef(g)`)
-	ret, err := htmlsanitizer.Sanitize(data)
-	if err != nil {
-		t.Errorf("unable to Sanitize err: %s", err)
-		return
-	}
-	if !bytes.Equal(ret, expected) {
-		t.Errorf("test failed for %s, expect %s, got %s", data, expected, ret)
-		return
-	}
-}

--- a/sanitizer_fuzz_test.go
+++ b/sanitizer_fuzz_test.go
@@ -1,0 +1,56 @@
+//go:build go1.18
+// +build go1.18
+
+package htmlsanitizer_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sym01/htmlsanitizer"
+)
+
+func FuzzSanitize(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(`xxls<<< <xx />`),
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, a []byte) {
+		data := append([]byte(`abc<script>`), a...)
+		data = append(data, `abc</script>def<style>`...)
+		data = append(data, a...)
+		data = append(data, `</style ...>(g)`...)
+		expected := []byte(`abcdef(g)`)
+		ret, err := htmlsanitizer.Sanitize(data)
+		if err != nil {
+			t.Errorf("unable to Sanitize err: %s", err)
+			return
+		}
+		if !bytes.Equal(ret, expected) {
+			t.Errorf("test failed for %s, expect %s, got %s", data, expected, ret)
+			return
+		}
+	})
+}
+
+func TestSanitize_tmp(t *testing.T) {
+	a := []byte(`</A>`)
+	data := append([]byte(`abc<script>`), a...)
+	data = append(data, `abc</script>def<style>`...)
+	data = append(data, a...)
+	data = append(data, `</style ...>(g)`...)
+	expected := []byte(`abcdef(g)`)
+	ret, err := htmlsanitizer.Sanitize(data)
+	if err != nil {
+		t.Errorf("unable to Sanitize err: %s", err)
+		return
+	}
+	if !bytes.Equal(ret, expected) {
+		t.Errorf("test failed for %s, expect %s, got %s", data, expected, ret)
+		return
+	}
+}

--- a/sanitizer_test.go
+++ b/sanitizer_test.go
@@ -499,6 +499,10 @@ var testCases = []struct {
 		out: `<a>XSS</a>`,
 	},
 	{
+		in:  `<span>func <a class= "Documentation-source" href="https://cs.opensource.google/go/go/+/go1.21.5:src/os/path.go;l=66">RemoveAll</a> <a class="Documentation-idLink" href="#RemoveAll" aria-label="Go to RemoveAll">¶</a></span>`,
+		out: `<span>func <a class="Documentation-source" href="https://cs.opensource.google/go/go/+/go1.21.5:src/os/path.go;l=66">RemoveAll</a> <a class="Documentation-idLink" href="#RemoveAll">¶</a></span>`,
+	},
+	{
 		in: `
 <Img src = x onerror = "javascript: window.onerror = alert; throw XSS">
 <Video> <source onerror = "javascript: alert (XSS)">

--- a/sanitizer_test.go
+++ b/sanitizer_test.go
@@ -1,4 +1,4 @@
-package htmlsanitizer
+package htmlsanitizer_test
 
 import (
 	"bytes"
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/sym01/htmlsanitizer"
 )
 
 func ExampleNewWriter() {
@@ -26,8 +28,8 @@ func ExampleNewWriter() {
 	// source reader for demo
 	r := bytes.NewBufferString(data)
 
-	sanitizedWriter := NewWriter(o)
-	io.Copy(sanitizedWriter, r)
+	sanitizedWriter := htmlsanitizer.NewWriter(o)
+	_, _ = io.Copy(sanitizedWriter, r)
 
 	// check the result, for demo only
 	fmt.Print(o.String() == expected)
@@ -36,7 +38,7 @@ func ExampleNewWriter() {
 }
 
 func ExampleHTMLSanitizer_noTagsAllowed() {
-	sanitizer := NewHTMLSanitizer()
+	sanitizer := htmlsanitizer.NewHTMLSanitizer()
 	// just set AllowList to nil to disable all tags
 	sanitizer.AllowList = nil
 
@@ -57,9 +59,9 @@ func ExampleHTMLSanitizer_noTagsAllowed() {
 
 func ExampleHTMLSanitizer_customURLSanitizer() {
 	// only links with domain name example.com are allowed.
-	sanitizer := NewHTMLSanitizer()
+	sanitizer := htmlsanitizer.NewHTMLSanitizer()
 	sanitizer.URLSanitizer = func(rawURL string) (newURL string, ok bool) {
-		newURL, ok = DefaultURLSanitizer(rawURL)
+		newURL, ok = htmlsanitizer.DefaultURLSanitizer(rawURL)
 		if !ok {
 			return
 		}
@@ -93,12 +95,12 @@ func ExampleHTMLSanitizer_customURLSanitizer() {
 func TestSanitize(t *testing.T) {
 	data := []byte(`<a class=x id= 123 href="javascript:alert(1)">demo</a>`)
 	expected := []byte(`<a class="x" id="123">demo</a>`)
-	ret, err := Sanitize(data)
+	ret, err := htmlsanitizer.Sanitize(data)
 	if err != nil {
 		t.Errorf("unable to Sanitize err: %s", err)
 		return
 	}
-	if bytes.Compare(ret, expected) != 0 {
+	if !bytes.Equal(ret, expected) {
 		t.Errorf("test failed for %s, expect %s, got %s", data, expected, ret)
 		return
 	}
@@ -106,7 +108,7 @@ func TestSanitize(t *testing.T) {
 
 func TestSanitizeString(t *testing.T) {
 	for _, item := range testCases {
-		ret, err := SanitizeString(item.in)
+		ret, err := htmlsanitizer.SanitizeString(item.in)
 
 		if err != nil {
 			t.Errorf("unable to SanitizeString(%#v) err: %s", item.in, err)
@@ -279,7 +281,7 @@ var testCases = []struct {
 		out: `<img>`,
 	},
 	{
-		in: `<IMG SRC="jav	ascript:alert('XSS');">`,
+		in:  `<IMG SRC="jav	ascript:alert('XSS');">`,
 		out: `<img>`,
 	},
 	{

--- a/sanitizer_test.go
+++ b/sanitizer_test.go
@@ -54,7 +54,9 @@ func ExampleHTMLSanitizer_keepStyleSheet() {
 		background-color: #f0f0f2;
 		margin: 0;
 		padding: 0;
-		bad-attr: <body>;
+		bad-attr: <body></body>;
+		bad-attr: <body></body >;
+		bad-attr: <body></ body>;
 		font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	}
 	</style>
@@ -77,7 +79,9 @@ func ExampleHTMLSanitizer_keepStyleSheet() {
 	//		background-color: #f0f0f2;
 	//		margin: 0;
 	//		padding: 0;
-	// 		bad-attr: &lt;body&gt;;
+	// 		bad-attr: &lt;body&gt;&lt;/body&gt;;
+	// 		bad-attr: &lt;body&gt;&lt;/body &gt;;
+	// 		bad-attr: &lt;body&gt;&lt;/ body&gt;;
 	//		font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	//	}
 	// 	</style>
@@ -204,7 +208,7 @@ var testCases = []struct {
 		out: "<a class=\"&#39;&lt;&gt;\" rel=\"aaa&#34;\">test</a>",
 	},
 	{
-		in:  `<a href="ftp://example.com/xxx">test</a>`,
+		in:  `<a href="ftp://example.com/xxx">test</a xxx>`,
 		out: "<a>test</a>",
 	},
 	{
@@ -278,7 +282,7 @@ var testCases = []struct {
 
 	// test cases from https://owasp.org/www-community/xss-filter-evasion-cheatsheet
 	{
-		in:  `<SCRIPT SRC=http://xss.rocks/xss.js></SCRIPT>`,
+		in:  `<SCRIPT SRC=http://xss.rocks/xss.js></SCRIPT xxx>`,
 		out: ``,
 	},
 	{
@@ -422,6 +426,10 @@ var testCases = []struct {
 		out: "<ul><li>XSS</br>",
 	},
 	{
+		in:  `<STYLE>li {list-style-image: url("javascript:alert('XSS')");}`,
+		out: "",
+	},
+	{
 		in:  `<svg/onload=alert('XSS')>`,
 		out: ``,
 	},
@@ -532,7 +540,7 @@ On Mouse Over​
 <input/onmouseover="javaSCRIPT&colon;confirm&lpar;1&rpar;"
 <iframe src="data:text/html,%3C%73%63%72%69%70%74%3E%61%6C%65%72%74%28%31%29%3C%2F%73%63%72%69%70%74%3E"></iframe>
 <OBJECT CLASSID="clsid:333C7BC4-460F-11D0-BC04-0080C7055A83"><PARAM NAME="DataURL" VALUE="javascript:alert(1)"></OBJECT>
-		`,
+`,
 		out: `
 <img src="x">
 <video> <source>
@@ -542,7 +550,10 @@ On Mouse Over​
 "&gt;”&gt;’&gt;
 "&gt;<img>
 "&gt;
-</img>
+
+
+<img alt="0">
+<img></img>
 
 
 
@@ -556,6 +567,6 @@ On Mouse Over​
 CLICKME
 
 
-		`,
+`,
 	},
 }

--- a/tags.go
+++ b/tags.go
@@ -56,6 +56,12 @@ type AllowList struct {
 	// For security reasons, it's not recommended to set a glboal attr for
 	// any URL-related attribute.
 	GlobalAttr []string
+
+	// NonHTMLTags defines a set of special tags, such as <script> and <style>.
+	// The content of these kind of tags is actually not a real HTML content.
+	// So we should treat it as a single element, without any child elements.
+	// TODO: rename this one
+	NonHTMLTags []*Tag
 }
 
 // attrExists checks whether global attr exists. Case sensitive
@@ -72,6 +78,23 @@ func (l *AllowList) attrExists(p []byte) bool {
 	}
 
 	return false
+}
+
+// checkNonHTMLTag checks if the given tag name is a non-html tag,
+// such as `script` and `style`. Return nil if it's not a non-html tag
+func (l *AllowList) checkNonHTMLTag(p []byte) *Tag {
+	if l == nil {
+		return nil
+	}
+
+	name := string(bytes.ToLower(p))
+	for _, tag := range l.NonHTMLTags {
+		if name == tag.Name {
+			return tag
+		}
+	}
+
+	return nil
 }
 
 // RemoveTag removes all tags name `name`, must be lowercase
@@ -121,6 +144,7 @@ func (l *AllowList) Clone() *AllowList {
 	newList := new(AllowList)
 	newList.Tags = append(newList.Tags, l.Tags...)
 	newList.GlobalAttr = append(newList.GlobalAttr, l.GlobalAttr...)
+	newList.NonHTMLTags = append(newList.NonHTMLTags, l.NonHTMLTags...)
 
 	return newList
 }
@@ -218,5 +242,10 @@ var DefaultAllowList = &AllowList{
 	GlobalAttr: []string{
 		"class",
 		"id",
+	},
+	NonHTMLTags: []*Tag{
+		{Name: "script"},
+		{Name: "style"},
+		{Name: "object"},
 	},
 }

--- a/tags_test.go
+++ b/tags_test.go
@@ -1,12 +1,14 @@
-package htmlsanitizer
+package htmlsanitizer_test
 
 import (
 	"fmt"
+
+	"github.com/sym01/htmlsanitizer"
 )
 
 func ExampleAllowList_RemoveTag() {
 	// sometimes we don't want user to pass HTML with <a> tag
-	sanitizer := NewHTMLSanitizer()
+	sanitizer := htmlsanitizer.NewHTMLSanitizer()
 	sanitizer.RemoveTag("a")
 
 	data := `

--- a/testdata/fuzz/FuzzSanitize/03462e3f96274bdf
+++ b/testdata/fuzz/FuzzSanitize/03462e3f96274bdf
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("<")

--- a/testdata/fuzz/FuzzSanitize/96a664493098a5ca
+++ b/testdata/fuzz/FuzzSanitize/96a664493098a5ca
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0000</")

--- a/testdata/fuzz/FuzzSanitize/a97dae8c7c203068
+++ b/testdata/fuzz/FuzzSanitize/a97dae8c7c203068
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("</A")

--- a/testdata/fuzz/FuzzSanitize/e5f8f45235847bc8
+++ b/testdata/fuzz/FuzzSanitize/e5f8f45235847bc8
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("</A>")


### PR DESCRIPTION
Thinking about the following HTML
```html
<body>
	<div>
	<h1>Example Domain</h1>
	<p><a href="https://www.iana.org/domains/example">More information...</a></p>
	</div>
	<script>alert(1)</script>
</body>
```

The expected output should be
```html

	<div>
	<h1>Example Domain</h1>
	<p><a href="https://www.iana.org/domains/example">More information...</a></p>
	</div>
	

```

However, in the previous version, the output looks like
```html

	<div>
	<h1>Example Domain</h1>
	<p><a href="https://www.iana.org/domains/example">More information...</a></p>
	</div>
	alert(1)

```

The output is unexpected. So we need to optimise the support for `<script>`, `<style>`.